### PR TITLE
Fix resource created by collect has no parent

### DIFF
--- a/src/app/app.controller.ts
+++ b/src/app/app.controller.ts
@@ -1,11 +1,12 @@
 import { Controller, Get } from '@nestjs/common';
 import { Public } from 'src/auth/decorators/public.decorator';
+import * as process from 'node:process';
 
 @Controller('api/v1/health')
 export class AppController {
   @Public()
   @Get()
   healthCheck() {
-    return '';
+    return { uptime: process.uptime() };
   }
 }

--- a/src/namespaces/namespaces.service.ts
+++ b/src/namespaces/namespaces.service.ts
@@ -40,12 +40,6 @@ export class NamespacesService {
     return namespace;
   }
 
-  async findByName(name: string) {
-    return await this.namespaceRepository.findOne({
-      where: { name },
-    });
-  }
-
   async create(userId: string, name: string) {
     const newNamespace = this.namespaceRepository.create({
       name,

--- a/src/wizard/dto/collect-request.dto.ts
+++ b/src/wizard/dto/collect-request.dto.ts
@@ -16,7 +16,7 @@ export class CollectRequestDto {
 
   @IsString()
   @IsNotEmpty()
-  namespace: string;
+  namespaceId: string;
 
   @IsEnum(SpaceType)
   @IsNotEmpty()

--- a/src/wizard/wizard.service.ts
+++ b/src/wizard/wizard.service.ts
@@ -77,33 +77,35 @@ export class WizardService {
   }
 
   async collect(user: User, data: CollectRequestDto) {
-    const { html, url, title, namespace, spaceType } = data;
-    if (!namespace || !spaceType || !url || !html) {
+    const { html, url, title, namespaceId, spaceType } = data;
+    if (!namespaceId || !spaceType || !url || !html) {
       throw new BadRequestException('Missing required fields');
     }
-    const ns = await this.namespacesService.findByName(namespace);
-    if (!ns) {
-      throw new NotFoundException('Namespace not found');
-    }
+    const namespace = await this.namespacesService.get(namespaceId);
 
-    // Actually create a resource using ResourcesService
+    const resourceRoot = await this.resourcesService.getRoot(
+      namespace.id,
+      spaceType,
+      user.id,
+    );
+
     const resourceDto: CreateResourceDto = {
       name: title || url,
-      namespace: ns.id,
+      namespace: namespace.id,
       resourceType: 'link',
       spaceType,
-      content: 'Processing...',
+      parentId: resourceRoot.id,
       attrs: { url },
     };
     const resource = await this.resourcesService.create(user, resourceDto);
     console.debug({ resource });
 
-    const payload = { spaceType, namespace, resourceId: resource.id };
+    const payload = { resourceId: resource.id };
 
     const task = await this.create({
       function: 'collect',
       input: { html, url, title },
-      namespace: ns,
+      namespace: namespace,
       payload,
       user,
     });

--- a/src/wizard/wizard.service.ts
+++ b/src/wizard/wizard.service.ts
@@ -92,8 +92,6 @@ export class WizardService {
       namespace: ns.id,
       resourceType: 'link',
       spaceType,
-      parentId: '',
-      tags: [],
       content: 'Processing...',
       attrs: { url },
     };


### PR DESCRIPTION
When creating a resource via the collect API, the resource's `parentId` is set to an empty string. This causes the backend to treat the resource as the root of the namespace, which result in an error.