### PR TITLE
fix(seo): Return 404 for missing content

### DIFF
--- a/src/seo/seo.controller.spec.ts
+++ b/src/seo/seo.controller.spec.ts
@@ -14,10 +14,11 @@ describe('SeoController', () => {
       { get: jest.fn() } as never,
     );
     const controller = new SeoController(service);
+    const setHeader = jest.fn();
     const status = jest.fn().mockReturnThis();
     const send = jest.fn();
     const response = {
-      setHeader: jest.fn(),
+      setHeader,
       status,
       send,
     } as unknown as Response;
@@ -25,6 +26,7 @@ describe('SeoController', () => {
     await controller.getShareSeoHtml('missing', response);
 
     expect(status).toHaveBeenCalledWith(HttpStatus.NOT_FOUND);
+    expect(setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
     expect(send).toHaveBeenCalledWith(
       expect.stringContaining('No share found'),
     );

--- a/src/seo/seo.controller.spec.ts
+++ b/src/seo/seo.controller.spec.ts
@@ -1,5 +1,6 @@
 import { HttpStatus } from '@nestjs/common';
 import { Response } from 'express';
+import { AppException } from 'omniboxd/common/exceptions/app.exception';
 import { SeoController } from 'omniboxd/seo/seo.controller';
 import { SeoService } from 'omniboxd/seo/seo.service';
 
@@ -7,6 +8,7 @@ describe('SeoController', () => {
   it('returns 404 HTML when a share does not exist', async () => {
     const service = new SeoService(
       { findOne: jest.fn().mockResolvedValue(null) } as never,
+      {} as never,
       {} as never,
       {} as never,
       { get: jest.fn() } as never,
@@ -26,5 +28,69 @@ describe('SeoController', () => {
     expect(send).toHaveBeenCalledWith(
       expect.stringContaining('No share found'),
     );
+  });
+
+  it('does not expose a resource outside the share scope', async () => {
+    const getAndValidateResource = jest
+      .fn()
+      .mockRejectedValue(
+        new AppException(
+          'Resource not found',
+          'RESOURCE_NOT_FOUND',
+          HttpStatus.NOT_FOUND,
+        ),
+      );
+    const service = new SeoService(
+      {
+        findOne: jest.fn().mockResolvedValue({
+          id: 'share-id',
+          enabled: true,
+          userId: 'owner-id',
+          expiresAt: null,
+          requireLogin: false,
+          password: null,
+          resourceId: 'root-resource-id',
+        }),
+      } as never,
+      {} as never,
+      {} as never,
+      { getAndValidateResource } as never,
+      { get: jest.fn() } as never,
+    );
+
+    const result = await service.generateShareHtml(
+      'share-id',
+      'private-resource-id',
+    );
+
+    expect(getAndValidateResource).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'share-id' }),
+      'private-resource-id',
+    );
+    expect(result.status).toBe(HttpStatus.NOT_FOUND);
+    expect(result.html).not.toContain('private content');
+  });
+
+  it('does not treat an indexed option value of false as public', async () => {
+    const service = new SeoService(
+      {} as never,
+      {
+        findOne: jest.fn().mockResolvedValue({
+          id: 'resource-id',
+          name: 'Private resource',
+          content: 'private content',
+          userId: 'owner-id',
+        }),
+      } as never,
+      { findOne: jest.fn().mockResolvedValue({ value: 'false' }) } as never,
+      {} as never,
+      { get: jest.fn() } as never,
+    );
+
+    const result = await service.getResourceHtml('namespace-id', 'resource-id');
+
+    expect(result.status).toBe(HttpStatus.OK);
+    expect(result.html).toContain('This content is protected');
+    expect(result.html).not.toContain('private content');
   });
 });

--- a/src/seo/seo.controller.spec.ts
+++ b/src/seo/seo.controller.spec.ts
@@ -1,0 +1,30 @@
+import { HttpStatus } from '@nestjs/common';
+import { Response } from 'express';
+import { SeoController } from 'omniboxd/seo/seo.controller';
+import { SeoService } from 'omniboxd/seo/seo.service';
+
+describe('SeoController', () => {
+  it('returns 404 HTML when a share does not exist', async () => {
+    const service = new SeoService(
+      { findOne: jest.fn().mockResolvedValue(null) } as never,
+      {} as never,
+      {} as never,
+      { get: jest.fn() } as never,
+    );
+    const controller = new SeoController(service);
+    const status = jest.fn().mockReturnThis();
+    const send = jest.fn();
+    const response = {
+      setHeader: jest.fn(),
+      status,
+      send,
+    } as unknown as Response;
+
+    await controller.getShareSeoHtml('missing', response);
+
+    expect(status).toHaveBeenCalledWith(HttpStatus.NOT_FOUND);
+    expect(send).toHaveBeenCalledWith(
+      expect.stringContaining('No share found'),
+    );
+  });
+});

--- a/src/seo/seo.controller.spec.ts
+++ b/src/seo/seo.controller.spec.ts
@@ -68,7 +68,6 @@ describe('SeoController', () => {
       'private-resource-id',
     );
     expect(result.status).toBe(HttpStatus.NOT_FOUND);
-    expect(result.html).not.toContain('private content');
   });
 
   it('does not treat an indexed option value of false as public', async () => {

--- a/src/seo/seo.controller.ts
+++ b/src/seo/seo.controller.ts
@@ -10,7 +10,7 @@ export class SeoController {
 
   private send(res: Response, response: SeoResponse) {
     res.setHeader('Content-Type', 'text/html; charset=utf-8');
-    res.setHeader('Cache-Control', 'public, max-age=300'); // Cache for 5 minutes
+    res.setHeader('Cache-Control', 'no-store');
     res.status(response.status).send(response.html);
   }
 

--- a/src/seo/seo.controller.ts
+++ b/src/seo/seo.controller.ts
@@ -1,17 +1,17 @@
 import { Controller, Get, Param, Res } from '@nestjs/common';
 import { Response } from 'express';
 import { Public } from 'omniboxd/auth/decorators/public.auth.decorator';
-import { SeoService } from 'omniboxd/seo/seo.service';
+import { SeoResponse, SeoService } from 'omniboxd/seo/seo.service';
 
 @Public()
 @Controller('api/v1/seo')
 export class SeoController {
   constructor(private readonly seoService: SeoService) {}
 
-  private send(res: Response, html: string) {
+  private send(res: Response, response: SeoResponse) {
     res.setHeader('Content-Type', 'text/html; charset=utf-8');
     res.setHeader('Cache-Control', 'public, max-age=300'); // Cache for 5 minutes
-    res.send(html);
+    res.status(response.status).send(response.html);
   }
 
   @Get('shares/:shareId')
@@ -19,8 +19,8 @@ export class SeoController {
     @Param('shareId') shareId: string,
     @Res() res: Response,
   ) {
-    const html = await this.seoService.generateShareHtml(shareId, null);
-    this.send(res, html);
+    const response = await this.seoService.generateShareHtml(shareId, null);
+    this.send(res, response);
   }
 
   @Get('shares/:shareId/:resourceId')
@@ -29,8 +29,11 @@ export class SeoController {
     @Param('resourceId') resourceId: string,
     @Res() res: Response,
   ) {
-    const html = await this.seoService.generateShareHtml(shareId, resourceId);
-    this.send(res, html);
+    const response = await this.seoService.generateShareHtml(
+      shareId,
+      resourceId,
+    );
+    this.send(res, response);
   }
 
   @Get('namespaces/:namespaceId/resources/:resourceId')
@@ -39,7 +42,10 @@ export class SeoController {
     @Param('resourceId') resourceId: string,
     @Res() res: Response,
   ) {
-    const html = await this.seoService.getResourceHtml(namespaceId, resourceId);
-    this.send(res, html);
+    const response = await this.seoService.getResourceHtml(
+      namespaceId,
+      resourceId,
+    );
+    this.send(res, response);
   }
 }

--- a/src/seo/seo.module.ts
+++ b/src/seo/seo.module.ts
@@ -3,11 +3,15 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Resource } from 'omniboxd/resources/entities/resource.entity';
 import { SeoController } from 'omniboxd/seo/seo.controller';
 import { SeoService } from 'omniboxd/seo/seo.service';
+import { SharedResourcesModule } from 'omniboxd/shared-resources/shared-resources.module';
 import { Share } from 'omniboxd/shares/entities/share.entity';
 import { UserOption } from 'omniboxd/user/entities/user-option.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Share, Resource, UserOption])],
+  imports: [
+    TypeOrmModule.forFeature([Share, Resource, UserOption]),
+    SharedResourcesModule,
+  ],
   controllers: [SeoController],
   providers: [SeoService],
   exports: [SeoService],

--- a/src/seo/seo.service.ts
+++ b/src/seo/seo.service.ts
@@ -14,6 +14,10 @@ export type SeoResponse = {
   status: HttpStatus;
 };
 
+function response(html: string, status = HttpStatus.OK): SeoResponse {
+  return { html, status };
+}
+
 @Injectable()
 export class SeoService {
   private readonly baseUrl: string;
@@ -42,32 +46,21 @@ export class SeoService {
       where: { id: shareId },
     });
 
-    if (!share || !share.enabled || !share.userId) {
-      return {
-        html: loadHtmlTemplate('No share found'),
-        status: HttpStatus.NOT_FOUND,
-      };
-    }
-
-    if (share.expiresAt && share.expiresAt < new Date()) {
-      return {
-        html: loadHtmlTemplate('No share found'),
-        status: HttpStatus.NOT_FOUND,
-      };
+    if (
+      !share ||
+      !share.enabled ||
+      !share.userId ||
+      (share.expiresAt && share.expiresAt < new Date())
+    ) {
+      return response(loadHtmlTemplate('No share found'), HttpStatus.NOT_FOUND);
     }
 
     if (share.requireLogin) {
-      return {
-        html: loadHtmlTemplate('This share requires login'),
-        status: HttpStatus.OK,
-      };
+      return response(loadHtmlTemplate('This share requires login'));
     }
 
     if (share.password) {
-      return {
-        html: loadHtmlTemplate('This content is password protected'),
-        status: HttpStatus.OK,
-      };
+      return response(loadHtmlTemplate('This content is password protected'));
     }
 
     const targetResourceId = resourceId || share.resourceId;
@@ -79,17 +72,17 @@ export class SeoService {
       );
     } catch (error) {
       if (error instanceof AppException && error.getStatus() === 404) {
-        return {
-          html: loadHtmlTemplate('Resource not found'),
-          status: HttpStatus.NOT_FOUND,
-        };
+        return response(
+          loadHtmlTemplate('Resource not found'),
+          HttpStatus.NOT_FOUND,
+        );
       }
       throw error;
     }
 
     const baseUrl = `${this.baseUrl}/s/${shareId}/${targetResourceId}`;
 
-    return { html: generateHTML(baseUrl, resource), status: HttpStatus.OK };
+    return response(generateHTML(baseUrl, resource));
   }
 
   async getResourceHtml(
@@ -102,10 +95,10 @@ export class SeoService {
     });
 
     if (!resource) {
-      return {
-        html: loadHtmlTemplate('Resource not found'),
-        status: HttpStatus.NOT_FOUND,
-      };
+      return response(
+        loadHtmlTemplate('Resource not found'),
+        HttpStatus.NOT_FOUND,
+      );
     }
 
     if (resource.userId) {
@@ -115,13 +108,10 @@ export class SeoService {
       if (option?.value === 'true') {
         const baseUrl = `${this.baseUrl}/${namespaceId}/${resourceId}`;
 
-        return { html: generateHTML(baseUrl, resource), status: HttpStatus.OK };
+        return response(generateHTML(baseUrl, resource));
       }
     }
 
-    return {
-      html: loadHtmlTemplate('This content is protected'),
-      status: HttpStatus.OK,
-    };
+    return response(loadHtmlTemplate('This content is protected'));
   }
 }

--- a/src/seo/seo.service.ts
+++ b/src/seo/seo.service.ts
@@ -1,8 +1,10 @@
 import { HttpStatus, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
+import { AppException } from 'omniboxd/common/exceptions/app.exception';
 import { Resource } from 'omniboxd/resources/entities/resource.entity';
 import { generateHTML, loadHtmlTemplate } from 'omniboxd/seo/utils';
+import { SharedResourcesService } from 'omniboxd/shared-resources/shared-resources.service';
 import { Share } from 'omniboxd/shares/entities/share.entity';
 import { UserOption } from 'omniboxd/user/entities/user-option.entity';
 import { Repository } from 'typeorm';
@@ -23,6 +25,7 @@ export class SeoService {
     private readonly resourceRepository: Repository<Resource>,
     @InjectRepository(UserOption)
     private readonly userOptionRepository: Repository<UserOption>,
+    private readonly sharedResourcesService: SharedResourcesService,
     private readonly configService: ConfigService,
   ) {
     this.baseUrl = this.configService.get<string>(
@@ -39,7 +42,7 @@ export class SeoService {
       where: { id: shareId },
     });
 
-    if (!share || !share.enabled) {
+    if (!share || !share.enabled || !share.userId) {
       return {
         html: loadHtmlTemplate('No share found'),
         status: HttpStatus.NOT_FOUND,
@@ -68,16 +71,20 @@ export class SeoService {
     }
 
     const targetResourceId = resourceId || share.resourceId;
-    const resource = await this.resourceRepository.findOne({
-      where: { id: targetResourceId },
-      select: ['id', 'name', 'content', 'attrs'],
-    });
-
-    if (!resource) {
-      return {
-        html: loadHtmlTemplate('Resource not found'),
-        status: HttpStatus.NOT_FOUND,
-      };
+    let resource: Resource;
+    try {
+      resource = await this.sharedResourcesService.getAndValidateResource(
+        share,
+        targetResourceId,
+      );
+    } catch (error) {
+      if (error instanceof AppException && error.getStatus() === 404) {
+        return {
+          html: loadHtmlTemplate('Resource not found'),
+          status: HttpStatus.NOT_FOUND,
+        };
+      }
+      throw error;
     }
 
     const baseUrl = `${this.baseUrl}/s/${shareId}/${targetResourceId}`;
@@ -105,7 +112,7 @@ export class SeoService {
       const option = await this.userOptionRepository.findOne({
         where: { userId: resource.userId, name: 'indexed' },
       });
-      if (option && option.value) {
+      if (option?.value === 'true') {
         const baseUrl = `${this.baseUrl}/${namespaceId}/${resourceId}`;
 
         return { html: generateHTML(baseUrl, resource), status: HttpStatus.OK };

--- a/src/seo/seo.service.ts
+++ b/src/seo/seo.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { HttpStatus, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Resource } from 'omniboxd/resources/entities/resource.entity';
@@ -6,6 +6,11 @@ import { generateHTML, loadHtmlTemplate } from 'omniboxd/seo/utils';
 import { Share } from 'omniboxd/shares/entities/share.entity';
 import { UserOption } from 'omniboxd/user/entities/user-option.entity';
 import { Repository } from 'typeorm';
+
+export type SeoResponse = {
+  html: string;
+  status: HttpStatus;
+};
 
 @Injectable()
 export class SeoService {
@@ -29,25 +34,37 @@ export class SeoService {
   async generateShareHtml(
     shareId: string,
     resourceId: string | null,
-  ): Promise<string> {
+  ): Promise<SeoResponse> {
     const share = await this.shareRepository.findOne({
       where: { id: shareId },
     });
 
     if (!share || !share.enabled) {
-      return loadHtmlTemplate('No share found');
+      return {
+        html: loadHtmlTemplate('No share found'),
+        status: HttpStatus.NOT_FOUND,
+      };
     }
 
     if (share.expiresAt && share.expiresAt < new Date()) {
-      return loadHtmlTemplate('No share found');
+      return {
+        html: loadHtmlTemplate('No share found'),
+        status: HttpStatus.NOT_FOUND,
+      };
     }
 
     if (share.requireLogin) {
-      return loadHtmlTemplate('This share requires login');
+      return {
+        html: loadHtmlTemplate('This share requires login'),
+        status: HttpStatus.OK,
+      };
     }
 
     if (share.password) {
-      return loadHtmlTemplate('This content is password protected');
+      return {
+        html: loadHtmlTemplate('This content is password protected'),
+        status: HttpStatus.OK,
+      };
     }
 
     const targetResourceId = resourceId || share.resourceId;
@@ -57,25 +74,31 @@ export class SeoService {
     });
 
     if (!resource) {
-      return loadHtmlTemplate('Resource not found');
+      return {
+        html: loadHtmlTemplate('Resource not found'),
+        status: HttpStatus.NOT_FOUND,
+      };
     }
 
     const baseUrl = `${this.baseUrl}/s/${shareId}/${targetResourceId}`;
 
-    return generateHTML(baseUrl, resource);
+    return { html: generateHTML(baseUrl, resource), status: HttpStatus.OK };
   }
 
   async getResourceHtml(
     namespaceId: string,
     resourceId: string,
-  ): Promise<string> {
+  ): Promise<SeoResponse> {
     const resource = await this.resourceRepository.findOne({
       where: { namespaceId, id: resourceId },
       select: ['id', 'name', 'content', 'userId'],
     });
 
     if (!resource) {
-      return loadHtmlTemplate('Resource not found');
+      return {
+        html: loadHtmlTemplate('Resource not found'),
+        status: HttpStatus.NOT_FOUND,
+      };
     }
 
     if (resource.userId) {
@@ -85,10 +108,13 @@ export class SeoService {
       if (option && option.value) {
         const baseUrl = `${this.baseUrl}/${namespaceId}/${resourceId}`;
 
-        return generateHTML(baseUrl, resource);
+        return { html: generateHTML(baseUrl, resource), status: HttpStatus.OK };
       }
     }
 
-    return loadHtmlTemplate('This content is protected');
+    return {
+      html: loadHtmlTemplate('This content is protected'),
+      status: HttpStatus.OK,
+    };
   }
 }


### PR DESCRIPTION
## Summary

- carry the HTTP status alongside generated SEO HTML
- return 404 for missing, disabled, or expired shares and missing resources
- reuse the public share resource validator so SEO cannot read resources outside the share scope
- require the indexed option to equal true before exposing namespace resource content
- prevent crawler-specific SEO responses from being cached and served to normal browsers
- preserve the existing response behavior for valid and protected content

## Testing

- pnpm exec jest src/seo/seo.controller.spec.ts --runInBand
- pnpm exec eslint src/seo/seo.controller.ts src/seo/seo.service.ts src/seo/seo.module.ts src/seo/seo.controller.spec.ts
- pnpm build