### PR TITLE
feat(smart-folders): Support Agent smart folder management

### DIFF
--- a/src/i18n/en/smartFolder.json
+++ b/src/i18n/en/smartFolder.json
@@ -2,7 +2,11 @@
   "errors": {
     "scopeInvalid": "Team smart folder can only filter teamspace resources",
     "quotaExceeded": "Smart folder quota exceeded",
-    "ruleLimitExceeded": "Smart folder rule limit exceeded",
+    "ruleLimitExceeded": "Too many smart folder conditions: received {received}. This workspace uses the {tier} tier, which allows at most {limit} conditions. Retry with {limit} or fewer conditions; if the folder already has {limit}, remove or replace one first.",
     "notFound": "Smart folder not found"
+  },
+  "tiers": {
+    "basic": "basic",
+    "premium": "premium"
   }
 }

--- a/src/i18n/zh/smartFolder.json
+++ b/src/i18n/zh/smartFolder.json
@@ -2,7 +2,11 @@
   "errors": {
     "scopeInvalid": "团队智能文件夹只能筛选团队空间资源",
     "quotaExceeded": "智能文件夹配额已用尽",
-    "ruleLimitExceeded": "智能文件夹规则数量超出限制",
+    "ruleLimitExceeded": "智能文件夹条件过多：收到 {received} 个条件。当前工作空间为{tier}，最多允许 {limit} 个条件。请使用不超过 {limit} 个条件重试；如果文件夹已有 {limit} 个条件，请先删除或替换一个条件。",
     "notFound": "智能文件夹未找到"
+  },
+  "tiers": {
+    "basic": "基础版",
+    "premium": "高级版"
   }
 }

--- a/src/namespace-resources/namespace-resources.service.spec.ts
+++ b/src/namespace-resources/namespace-resources.service.spec.ts
@@ -2,7 +2,7 @@ import { ResourceType } from 'omniboxd/resources/entities/resource.entity';
 
 import { NamespaceResourcesService } from './namespace-resources.service';
 
-describe('NamespaceResourcesService.listChildren', () => {
+describe('NamespaceResourcesService', () => {
   const namespaceId = 'namespace-1';
   const resourceId = 'smart-folder-1';
   const userId = 'user-1';
@@ -11,6 +11,7 @@ describe('NamespaceResourcesService.listChildren', () => {
     const resourcesService = {
       getParentResourcesOrFail: jest.fn(),
       getChildren: jest.fn(),
+      resourceFilter: jest.fn(),
     };
     const smartFoldersService = {
       listChildren: jest.fn(),
@@ -68,5 +69,16 @@ describe('NamespaceResourcesService.listChildren', () => {
     );
     expect(resourcesService.getChildren).not.toHaveBeenCalled();
     expect(result).toBe(children);
+  });
+
+  it('returns an empty filter result when no resources are accessible', async () => {
+    const { resourcesService, service } = createService();
+
+    await expect(
+      service.resourceFilter(namespaceId, [], {
+        resourceTypes: [ResourceType.SMART_FOLDER],
+      }),
+    ).resolves.toEqual({ resources: [], total: 0 });
+    expect(resourcesService.resourceFilter).not.toHaveBeenCalled();
   });
 });

--- a/src/namespace-resources/namespace-resources.service.ts
+++ b/src/namespace-resources/namespace-resources.service.ts
@@ -1428,6 +1428,10 @@ export class NamespaceResourcesService {
       limit?: number;
     },
   ): Promise<{ resources: InternalResourceDto[]; total: number }> {
+    if (resourceIds.length === 0) {
+      return { resources: [], total: 0 };
+    }
+
     let tagIds: string[] | undefined = undefined;
     if (!isOptional(options?.tagPattern)) {
       const tagEntities = await this.tagService.findByPattern(

--- a/src/smart-folders/internal.smart-folders.controller.ts
+++ b/src/smart-folders/internal.smart-folders.controller.ts
@@ -1,0 +1,50 @@
+import { Body, Controller, Get, Param, Patch, Post } from '@nestjs/common';
+import { Public } from 'omniboxd/auth/decorators/public.auth.decorator';
+import { HeaderUserId } from 'omniboxd/decorators/header-user-id.decorator';
+import { CheckNamespaceReadonly } from 'omniboxd/namespaces/decorators/check-storage-quota.decorator';
+import { CreateSmartFolderRequestDto } from 'omniboxd/smart-folders/dto/create-smart-folder-request.dto';
+import { UpdateSmartFolderRequestDto } from 'omniboxd/smart-folders/dto/update-smart-folder-request.dto';
+import { SmartFoldersService } from 'omniboxd/smart-folders/smart-folders.service';
+
+@Controller('internal/api/v1/namespaces/:namespaceId/smart-folders')
+export class InternalSmartFoldersController {
+  constructor(private readonly smartFoldersService: SmartFoldersService) {}
+
+  @Public()
+  @Post()
+  @CheckNamespaceReadonly()
+  async create(
+    @HeaderUserId() userId: string,
+    @Param('namespaceId') namespaceId: string,
+    @Body() dto: CreateSmartFolderRequestDto,
+  ) {
+    return await this.smartFoldersService.create(userId, namespaceId, dto);
+  }
+
+  @Public()
+  @Get(':resourceId/config')
+  async getConfig(
+    @HeaderUserId() userId: string,
+    @Param('namespaceId') namespaceId: string,
+    @Param('resourceId') resourceId: string,
+  ) {
+    return await this.smartFoldersService.get(userId, namespaceId, resourceId);
+  }
+
+  @Public()
+  @Patch(':resourceId/config')
+  @CheckNamespaceReadonly()
+  async updateConfig(
+    @HeaderUserId() userId: string,
+    @Param('namespaceId') namespaceId: string,
+    @Param('resourceId') resourceId: string,
+    @Body() dto: UpdateSmartFolderRequestDto,
+  ) {
+    return await this.smartFoldersService.update(
+      userId,
+      namespaceId,
+      resourceId,
+      dto,
+    );
+  }
+}

--- a/src/smart-folders/smart-folders-quota.service.spec.ts
+++ b/src/smart-folders/smart-folders-quota.service.spec.ts
@@ -47,11 +47,11 @@ describe('SmartFoldersQuotaService', () => {
       i18n as any,
     );
 
-    return { entitlementsProvider, queryBuilder, service };
+    return { entitlementsProvider, i18n, queryBuilder, service };
   }
 
   it('rejects create when rule count exceeds entitlement limit', async () => {
-    const { service } = createService({ ruleLimit: 1 });
+    const { i18n, service } = createService({ ruleLimit: 1 });
 
     await expect(
       service.assertEntitlements(
@@ -62,7 +62,10 @@ describe('SmartFoldersQuotaService', () => {
       ),
     ).rejects.toMatchObject<Partial<AppException>>({
       code: 'SMART_FOLDER_RULE_LIMIT_EXCEEDED',
+      message:
+        'Too many smart folder conditions: received 2, but the current plan allows at most 1. Retry with 1 or fewer conditions.',
     });
+    expect(i18n.t).not.toHaveBeenCalled();
   });
 
   it('rejects create when active folder count reaches owner-scope quota', async () => {

--- a/src/smart-folders/smart-folders-quota.service.spec.ts
+++ b/src/smart-folders/smart-folders-quota.service.spec.ts
@@ -66,10 +66,20 @@ describe('SmartFoldersQuotaService', () => {
       ),
     ).rejects.toMatchObject<Partial<AppException>>({
       code: 'SMART_FOLDER_RULE_LIMIT_EXCEEDED',
-      message:
-        'Too many smart folder conditions: received 11. This workspace uses the premium tier, which allows at most 10 conditions. Retry with 10 or fewer conditions; if the folder already has 10, remove or replace one first.',
+      message: 'smartFolder.errors.ruleLimitExceeded',
     });
-    expect(i18n.t).not.toHaveBeenCalled();
+    expect(i18n.t).toHaveBeenNthCalledWith(1, 'smartFolder.tiers.premium');
+    expect(i18n.t).toHaveBeenNthCalledWith(
+      2,
+      'smartFolder.errors.ruleLimitExceeded',
+      {
+        args: {
+          received: 11,
+          tier: 'smartFolder.tiers.premium',
+          limit: 10,
+        },
+      },
+    );
   });
 
   it('rejects create when active folder count reaches owner-scope quota', async () => {

--- a/src/smart-folders/smart-folders-quota.service.spec.ts
+++ b/src/smart-folders/smart-folders-quota.service.spec.ts
@@ -13,6 +13,7 @@ describe('SmartFoldersQuotaService', () => {
   }
 
   function createService(values?: {
+    tier?: 'basic' | 'premium';
     privateLimit?: number;
     teamLimit?: number;
     ruleLimit?: number;
@@ -20,7 +21,7 @@ describe('SmartFoldersQuotaService', () => {
   }) {
     const entitlementsProvider = {
       getEntitlements: jest.fn().mockResolvedValue({
-        tier: 'basic',
+        tier: values?.tier ?? 'basic',
         privateLimit: values?.privateLimit ?? 2,
         teamLimit: values?.teamLimit ?? 2,
         privateUsed: 0,
@@ -51,19 +52,22 @@ describe('SmartFoldersQuotaService', () => {
   }
 
   it('rejects create when rule count exceeds entitlement limit', async () => {
-    const { i18n, service } = createService({ ruleLimit: 1 });
+    const { i18n, service } = createService({
+      tier: 'premium',
+      ruleLimit: 10,
+    });
 
     await expect(
       service.assertEntitlements(
         'namespace-id',
         'user-id',
         SmartFolderOwnerScope.PRIVATE,
-        2,
+        11,
       ),
     ).rejects.toMatchObject<Partial<AppException>>({
       code: 'SMART_FOLDER_RULE_LIMIT_EXCEEDED',
       message:
-        'Too many smart folder conditions: received 2, but the current plan allows at most 1. Retry with 1 or fewer conditions.',
+        'Too many smart folder conditions: received 11. This workspace uses the premium tier, which allows at most 10 conditions. Retry with 10 or fewer conditions; if the folder already has 10, remove or replace one first.',
     });
     expect(i18n.t).not.toHaveBeenCalled();
   });

--- a/src/smart-folders/smart-folders-quota.service.ts
+++ b/src/smart-folders/smart-folders-quota.service.ts
@@ -78,7 +78,7 @@ export class SmartFoldersQuotaService {
     );
     if (ruleCount > entitlements.ruleLimit) {
       throw new AppException(
-        `Too many smart folder conditions: received ${ruleCount}, but the current plan allows at most ${entitlements.ruleLimit}. Retry with ${entitlements.ruleLimit} or fewer conditions.`,
+        `Too many smart folder conditions: received ${ruleCount}. This workspace uses the ${entitlements.tier} tier, which allows at most ${entitlements.ruleLimit} conditions. Retry with ${entitlements.ruleLimit} or fewer conditions; if the folder already has ${entitlements.ruleLimit}, remove or replace one first.`,
         'SMART_FOLDER_RULE_LIMIT_EXCEEDED',
         HttpStatus.UNPROCESSABLE_ENTITY,
       );

--- a/src/smart-folders/smart-folders-quota.service.ts
+++ b/src/smart-folders/smart-folders-quota.service.ts
@@ -77,8 +77,16 @@ export class SmartFoldersQuotaService {
       userId,
     );
     if (ruleCount > entitlements.ruleLimit) {
+      const tier = this.i18n.t(`smartFolder.tiers.${entitlements.tier}`);
+      const message = this.i18n.t('smartFolder.errors.ruleLimitExceeded', {
+        args: {
+          received: ruleCount,
+          tier,
+          limit: entitlements.ruleLimit,
+        },
+      });
       throw new AppException(
-        `Too many smart folder conditions: received ${ruleCount}. This workspace uses the ${entitlements.tier} tier, which allows at most ${entitlements.ruleLimit} conditions. Retry with ${entitlements.ruleLimit} or fewer conditions; if the folder already has ${entitlements.ruleLimit}, remove or replace one first.`,
+        message,
         'SMART_FOLDER_RULE_LIMIT_EXCEEDED',
         HttpStatus.UNPROCESSABLE_ENTITY,
       );

--- a/src/smart-folders/smart-folders-quota.service.ts
+++ b/src/smart-folders/smart-folders-quota.service.ts
@@ -77,11 +77,8 @@ export class SmartFoldersQuotaService {
       userId,
     );
     if (ruleCount > entitlements.ruleLimit) {
-      const message = this.i18n.t(
-        'resource.errors.smartFolderRuleLimitExceeded',
-      );
       throw new AppException(
-        message,
+        `Too many smart folder conditions: received ${ruleCount}, but the current plan allows at most ${entitlements.ruleLimit}. Retry with ${entitlements.ruleLimit} or fewer conditions.`,
         'SMART_FOLDER_RULE_LIMIT_EXCEEDED',
         HttpStatus.UNPROCESSABLE_ENTITY,
       );

--- a/src/smart-folders/smart-folders.module.ts
+++ b/src/smart-folders/smart-folders.module.ts
@@ -7,6 +7,7 @@ import { PermissionsModule } from 'omniboxd/permissions/permissions.module';
 import { Resource } from 'omniboxd/resources/entities/resource.entity';
 import { ResourcesModule } from 'omniboxd/resources/resources.module';
 import { SmartFolderConfig } from 'omniboxd/smart-folders/entities/smart-folder-config.entity';
+import { InternalSmartFoldersController } from 'omniboxd/smart-folders/internal.smart-folders.controller';
 import { SmartFolderEntitlementsController } from 'omniboxd/smart-folders/smart-folder-entitlements.controller';
 import {
   SMART_FOLDER_ENTITLEMENTS_PROVIDER,
@@ -52,7 +53,11 @@ import { TagModule } from 'omniboxd/tag/tag.module';
       useExisting: SmartFoldersService,
     },
   ],
-  controllers: [SmartFolderEntitlementsController, SmartFoldersController],
+  controllers: [
+    InternalSmartFoldersController,
+    SmartFolderEntitlementsController,
+    SmartFoldersController,
+  ],
   exports: [
     SmartFoldersService,
     SmartFoldersRuleService,


### PR DESCRIPTION
## Summary
- add internal smart folder create, config read, and config update routes
- reuse the existing service so permissions, readonly checks, transactions, and plan quotas stay consistent
- return actionable English errors with the received and allowed condition counts

## Testing
- pnpm run lint
- pnpm run test -- src/smart-folders --runInBand
- pnpm run build
- local internal API and Agent end-to-end smoke tests