### PR TITLE
feat(wizard): Support OmniBox resource URLs

### DIFF
--- a/src/i18n/en/wizard.json
+++ b/src/i18n/en/wizard.json
@@ -2,6 +2,7 @@
   "errors": {
     "missingFile": "Missing file",
     "missingRequiredFields": "Missing required fields",
+    "cannotCollectOmniBoxUrl": "OmniBox links cannot be collected back into OmniBox. Open or read the resource directly instead.",
     "invalidTaskPayload": "Invalid task payload",
     "taskNotStarted": "Task {taskId} has not been started yet"
   }

--- a/src/i18n/zh/wizard.json
+++ b/src/i18n/zh/wizard.json
@@ -2,6 +2,7 @@
   "errors": {
     "missingFile": "缺少文件",
     "missingRequiredFields": "缺少必填字段",
+    "cannotCollectOmniBoxUrl": "暂不支持把 OmniBox 链接收藏回 OmniBox，请直接打开或读取该资源。",
     "invalidTaskPayload": "无效的任务载荷",
     "taskNotStarted": "任务 {taskId} 尚未开始"
   }

--- a/src/open-api/open.skill.e2e-spec.ts
+++ b/src/open-api/open.skill.e2e-spec.ts
@@ -19,6 +19,7 @@ describe('OpenSkillController (e2e)', () => {
 
     expect(response.headers['content-type']).toContain('text/markdown');
     expect(response.text).toContain('/open/api/v1');
+    expect(response.text).toContain('/<namespace_id>/<resource_id>');
     expect(response.text).not.toContain('${OBB_OPEN_API_BASE_URL}');
     expect(response.text).not.toContain('OBB_OPEN_API_BASE_URL');
   });

--- a/src/open-api/templates/SKILL.md
+++ b/src/open-api/templates/SKILL.md
@@ -77,11 +77,10 @@ Use `GET /api-keys/info` to inspect `open_api_requests_quota.limit`, `used`, `re
 
 ### Understand OmniBox workspace resource URLs
 
-OmniBox workspace resource URLs use these path routes:
+OmniBox workspace resource URLs use this path route:
 
 ```text
-/<namespace_id>/<resource_id>
-/<namespace_id>/<resource_id>/edit
+/<namespace_id>/<resource_id>[/edit]
 ```
 
 The first path segment is the namespace ID and the second is the resource ID. The optional `/edit` suffix, query string, and fragment do not change those IDs. When given one of these URLs, compare its namespace ID with the namespace returned by `GET /api-keys/info`, then read the resource with `GET /resources/<resource_id>`.

--- a/src/open-api/templates/SKILL.md
+++ b/src/open-api/templates/SKILL.md
@@ -75,6 +75,17 @@ Use `GET /api-keys/info` to inspect `open_api_requests_quota.limit`, `used`, `re
 
 ## Common workflows
 
+### Understand OmniBox workspace resource URLs
+
+OmniBox workspace resource URLs use these path routes:
+
+```text
+/<namespace_id>/<resource_id>
+/<namespace_id>/<resource_id>/edit
+```
+
+The first path segment is the namespace ID and the second is the resource ID. The optional `/edit` suffix, query string, and fragment do not change those IDs. When given one of these URLs, compare its namespace ID with the namespace returned by `GET /api-keys/info`, then read the resource with `GET /resources/<resource_id>`.
+
 ### Inspect the current API key
 
 Call this first when you need to understand the key's namespace, root resource, and permissions.

--- a/src/wizard/dto/collect-url-request.dto.ts
+++ b/src/wizard/dto/collect-url-request.dto.ts
@@ -9,7 +9,11 @@ export class BaseCollectUrlRequestDto {
     example: 'https://example.com/article',
   })
   @IsUrl(
-    { protocols: ['http', 'https'], require_protocol: true },
+    {
+      protocols: ['http', 'https'],
+      require_protocol: true,
+      require_tld: false,
+    },
     {
       message: i18nValidationMessage('validation.errors.url.isUrl'),
     },

--- a/src/wizard/dto/internal-collect-url-request.dto.ts
+++ b/src/wizard/dto/internal-collect-url-request.dto.ts
@@ -7,7 +7,11 @@ export class InternalCollectUrlRequestDto {
   @Expose({ name: 'parent_id' })
   parentId: string;
 
-  @IsUrl({ protocols: ['http', 'https'], require_protocol: true })
+  @IsUrl({
+    protocols: ['http', 'https'],
+    require_protocol: true,
+    require_tld: false,
+  })
   @IsNotEmpty()
   @IsString()
   url: string;

--- a/src/wizard/wizard.service.spec.ts
+++ b/src/wizard/wizard.service.spec.ts
@@ -47,12 +47,22 @@ describe('WizardService', () => {
     });
 
     it.each([
-      'https://www.omnibox.pro/1DnZTW/DO3H9lDu8AXFjbuJ',
-      'https://box.example.com/abc123/0123456789ABCDEF',
-      'http://localhost:5193/abc123/0123456789ABCDEF/edit?mode=write#top',
-    ])('rejects an OmniBox URL: %s', async (url) => {
+      [
+        'https://www.omnibox.pro',
+        'https://www.omnibox.pro/1DnZTW/DO3H9lDu8AXFjbuJ',
+      ],
+      [
+        'https://box.example.com',
+        'https://box.example.com/abc123/0123456789ABCDEF',
+      ],
+      [
+        'http://localhost:5193',
+        'http://localhost:3000/any-path?mode=write#top',
+      ],
+    ])('rejects its own hostname: %s', async (baseUrl, url) => {
       const namespaceResourcesService = { create: jest.fn() };
       const i18n = { t: jest.fn((key: string) => key) };
+      const configService = { get: jest.fn().mockReturnValue(baseUrl) };
       const service = new WizardService(
         {} as any,
         {} as any,
@@ -62,6 +72,7 @@ describe('WizardService', () => {
         {} as any,
         {} as any,
         i18n as any,
+        configService as any,
       );
 
       await expect(
@@ -73,6 +84,34 @@ describe('WizardService', () => {
         'wizard.errors.cannotCollectOmniBoxUrl',
       );
       expect(namespaceResourcesService.create).not.toHaveBeenCalled();
+    });
+
+    it('allows a different hostname regardless of its path', async () => {
+      const wizardTaskService = { emitCollectUrlTask: jest.fn() };
+      const namespaceResourcesService = {
+        create: jest.fn().mockResolvedValue({ id: 'resource-id' }),
+      };
+      const service = new WizardService(
+        wizardTaskService as any,
+        {} as any,
+        namespaceResourcesService as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        { t: jest.fn() } as any,
+        { get: jest.fn().mockReturnValue('https://box.example.com') } as any,
+      );
+
+      await expect(
+        service.collectUrl(
+          'namespace-id',
+          'user-id',
+          'https://external.example/abc123/0123456789ABCDEF',
+          'parent-id',
+        ),
+      ).resolves.toMatchObject({ resourceId: 'resource-id' });
+      expect(namespaceResourcesService.create).toHaveBeenCalled();
     });
   });
 
@@ -101,6 +140,7 @@ describe('WizardService', () => {
         {} as any,
         { getResourceOrFail: jest.fn() } as any,
         i18n as any,
+        { get: jest.fn().mockReturnValue('https://www.omnibox.pro') } as any,
       );
       const message =
         '当前文件内容（32769 字符）超过系统可处理上限（32768 字符），请尝试拆分文档后重新上传。';

--- a/src/wizard/wizard.service.spec.ts
+++ b/src/wizard/wizard.service.spec.ts
@@ -1,5 +1,8 @@
+import { validate } from 'class-validator';
 import { Task, TaskStatus } from 'omniboxd/tasks/tasks.entity';
 
+import { OpenCollectUrlRequestDto } from './dto/collect-url-request.dto';
+import { InternalCollectUrlRequestDto } from './dto/internal-collect-url-request.dto';
 import { WizardService } from './wizard.service';
 
 const createTask = (overrides: Partial<Task> = {}): Task => ({
@@ -27,6 +30,52 @@ const createTask = (overrides: Partial<Task> = {}): Task => ({
 });
 
 describe('WizardService', () => {
+  describe('collectUrl', () => {
+    it('accepts localhost URLs through public and internal request validation', async () => {
+      const url =
+        'http://localhost:5193/abc123/0123456789ABCDEF/edit?mode=write#top';
+      const publicRequest = Object.assign(new OpenCollectUrlRequestDto(), {
+        url,
+      });
+      const internalRequest = Object.assign(
+        new InternalCollectUrlRequestDto(),
+        { url, parentId: 'parent-id' },
+      );
+
+      await expect(validate(publicRequest)).resolves.toHaveLength(0);
+      await expect(validate(internalRequest)).resolves.toHaveLength(0);
+    });
+
+    it.each([
+      'https://www.omnibox.pro/1DnZTW/DO3H9lDu8AXFjbuJ',
+      'https://box.example.com/abc123/0123456789ABCDEF',
+      'http://localhost:5193/abc123/0123456789ABCDEF/edit?mode=write#top',
+    ])('rejects an OmniBox URL: %s', async (url) => {
+      const namespaceResourcesService = { create: jest.fn() };
+      const i18n = { t: jest.fn((key: string) => key) };
+      const service = new WizardService(
+        {} as any,
+        {} as any,
+        namespaceResourcesService as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        i18n as any,
+      );
+
+      await expect(
+        service.collectUrl('namespace-id', 'user-id', url, 'parent-id'),
+      ).rejects.toMatchObject({
+        code: 'CANNOT_COLLECT_OMNIBOX_URL',
+      });
+      expect(i18n.t).toHaveBeenCalledWith(
+        'wizard.errors.cannotCollectOmniBoxUrl',
+      );
+      expect(namespaceResourcesService.create).not.toHaveBeenCalled();
+    });
+  });
+
   describe('taskDoneCallback', () => {
     it('keeps content-too-long callbacks as error and does not dispatch next tasks', async () => {
       const task = createTask();

--- a/src/wizard/wizard.service.ts
+++ b/src/wizard/wizard.service.ts
@@ -180,6 +180,20 @@ export class WizardService {
       );
     }
 
+    const path = new URL(url).pathname.split('/').filter(Boolean);
+    const isOmniBoxResourceUrl =
+      (path.length === 2 || (path.length === 3 && path[2] === 'edit')) &&
+      /^[a-zA-Z0-9]{6}$/.test(path[0]) &&
+      /^[a-zA-Z0-9]{16}$/.test(path[1]);
+    if (isOmniBoxResourceUrl) {
+      const message = this.i18n.t('wizard.errors.cannotCollectOmniBoxUrl');
+      throw new AppException(
+        message,
+        'CANNOT_COLLECT_OMNIBOX_URL',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
     // Create a placeholder resource for the URL
     const resourceDto: CreateResourceDto = {
       name: url,

--- a/src/wizard/wizard.service.ts
+++ b/src/wizard/wizard.service.ts
@@ -1,6 +1,7 @@
 import { buffer } from 'node:stream/consumers';
 
 import { HttpStatus, Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { I18nService } from 'nestjs-i18n';
 import { AttachmentsService } from 'omniboxd/attachments/attachments.service';
 import { AppException } from 'omniboxd/common/exceptions/app.exception';
@@ -40,6 +41,7 @@ export class WizardService {
   private readonly processors: Record<string, Processor>;
 
   private readonly gzipHtmlFolder: string = 'collect/html/gzip';
+  private readonly baseHostname: string;
 
   constructor(
     private readonly wizardTaskService: WizardTaskService,
@@ -50,7 +52,12 @@ export class WizardService {
     private readonly s3Service: S3Service,
     private readonly resourcesService: ResourcesService,
     private readonly i18n: I18nService,
+    private readonly configService: ConfigService,
   ) {
+    this.baseHostname = new URL(
+      this.configService.get<string>('OBB_BASE_URL', 'https://www.omnibox.pro'),
+    ).hostname;
+
     // All file_reader_* kinds share post-processing; one ReaderProcessor instance
     // is registered under every per-format kind. The legacy `file_reader` name is
     // also registered so tasks emitted before the per-format split still get
@@ -180,12 +187,7 @@ export class WizardService {
       );
     }
 
-    const path = new URL(url).pathname.split('/').filter(Boolean);
-    const isOmniBoxResourceUrl =
-      (path.length === 2 || (path.length === 3 && path[2] === 'edit')) &&
-      /^[a-zA-Z0-9]{6}$/.test(path[0]) &&
-      /^[a-zA-Z0-9]{16}$/.test(path[1]);
-    if (isOmniBoxResourceUrl) {
+    if (new URL(url).hostname === this.baseHostname) {
       const message = this.i18n.t('wizard.errors.cannotCollectOmniBoxUrl');
       throw new AppException(
         message,


### PR DESCRIPTION
## Summary

- document domain-independent workspace resource path routes in the Open API Skill
- reject OmniBox resource routes in collect_url with a localized friendly error
- allow localhost and self-hosted URLs through request validation so the guard can handle them

## Testing

- pnpm run test -- src/wizard/wizard.service.spec.ts --runInBand
- pnpm run lint
- manual local API checks for custom-domain and localhost URLs

## Not run

- Open Skill e2e test (Docker/Testcontainers unavailable locally)