### PR TITLE
fix(mail): Format email change time in Beijing timezone

### DIFF
--- a/src/mail/mail.service.spec.ts
+++ b/src/mail/mail.service.spec.ts
@@ -23,13 +23,13 @@ describe('MailService', () => {
     jest.useRealTimers();
   });
 
-  it('formats the change time in China Standard Time', async () => {
+  it('formats zh-CN change time in China Standard Time', async () => {
     await service.sendEmailChangeNotification(
       'old@example.com',
       'old@example.com',
       'new@example.com',
       'user',
-      'zh',
+      'zh-CN',
     );
 
     expect(sendMail).toHaveBeenCalledWith(

--- a/src/mail/mail.service.spec.ts
+++ b/src/mail/mail.service.spec.ts
@@ -1,0 +1,43 @@
+import { MailerService } from '@nestjs-modules/mailer';
+import { I18nService } from 'nestjs-i18n';
+
+import { MailService } from './mail.service';
+
+describe('MailService', () => {
+  const sendMail = jest.fn();
+  const i18n = {
+    t: jest.fn().mockReturnValue('Email change notification'),
+  };
+  const service = new MailService(
+    { sendMail } as unknown as MailerService,
+    i18n as unknown as I18nService,
+  );
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(Date.parse('2025-12-15T06:11:00Z'));
+    sendMail.mockReset().mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('formats the change time in China Standard Time', async () => {
+    await service.sendEmailChangeNotification(
+      'old@example.com',
+      'old@example.com',
+      'new@example.com',
+      'user',
+      'zh',
+    );
+
+    expect(sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          changeTime: '2025年12月15日 中国标准时间 14:11',
+        }),
+      }),
+    );
+  });
+});

--- a/src/mail/mail.service.ts
+++ b/src/mail/mail.service.ts
@@ -87,7 +87,7 @@ export class MailService {
     });
 
     const changeTime = new Date().toLocaleString(
-      lang === 'zh' ? 'zh-CN' : 'en-US',
+      lang?.startsWith('zh') ? 'zh-CN' : 'en-US',
       {
         year: 'numeric',
         month: 'long',

--- a/src/mail/mail.service.ts
+++ b/src/mail/mail.service.ts
@@ -94,7 +94,8 @@ export class MailService {
         day: 'numeric',
         hour: '2-digit',
         minute: '2-digit',
-        timeZoneName: 'short',
+        timeZone: 'Asia/Shanghai',
+        timeZoneName: 'long',
       },
     );
 


### PR DESCRIPTION
## Summary

- format email change notification timestamps in Asia/Shanghai
- display the full China Standard Time name in localized emails
- add unit coverage for UTC-to-Beijing-time conversion

## Verification

- pnpm run test -- src/mail/mail.service.spec.ts --runInBand
- eslint src/mail/mail.service.ts src/mail/mail.service.spec.ts
- pnpm run build
- local backend health check