### PR TITLE
fix(conversations): Enforce conversation access control

### DIFF
--- a/src/conversations/conversations.controller.ts
+++ b/src/conversations/conversations.controller.ts
@@ -47,23 +47,39 @@ export class ConversationsController {
 
   @Patch(':id')
   async update(
+    @UserId() userId: string,
+    @Param('namespaceId') namespaceId: string,
     @Param('id') id: string,
     @Body() updateConversationDto: UpdateConversationDto,
   ) {
-    await this.conversationsService.update(id, updateConversationDto.title);
+    await this.conversationsService.update(
+      namespaceId,
+      id,
+      userId,
+      updateConversationDto.title,
+    );
   }
 
   @Get(':id')
   async get(
+    @Param('namespaceId') namespaceId: string,
     @Param('id') id: string,
     @UserId() userId: string,
   ): Promise<ConversationDetailDto> {
-    return await this.conversationsService.getConversationForUser(id, userId);
+    return await this.conversationsService.getConversationForUser(
+      namespaceId,
+      id,
+      userId,
+    );
   }
 
   @Post(':id/title')
-  async createTitle(@Param('id') id: string, @UserId() userId: string) {
-    return await this.conversationsService.createTitle(id, userId);
+  async createTitle(
+    @Param('namespaceId') namespaceId: string,
+    @Param('id') id: string,
+    @UserId() userId: string,
+  ) {
+    return await this.conversationsService.createTitle(namespaceId, id, userId);
   }
 
   @Delete(':id')

--- a/src/conversations/conversations.e2e-spec.ts
+++ b/src/conversations/conversations.e2e-spec.ts
@@ -42,7 +42,7 @@ describe('ConversationsController (e2e)', () => {
     it('should fail with invalid namespaceId', async () => {
       await client
         .post('/api/v1/namespaces/invalid-namespace/conversations')
-        .expect(HttpStatus.INTERNAL_SERVER_ERROR); // Changed from FORBIDDEN
+        .expect(HttpStatus.FORBIDDEN);
     });
   });
 
@@ -107,7 +107,7 @@ describe('ConversationsController (e2e)', () => {
     it('should fail with invalid namespaceId', async () => {
       await client
         .get('/api/v1/namespaces/invalid-namespace/conversations')
-        .expect(HttpStatus.OK); // Changed from FORBIDDEN - API doesn't validate namespace ownership for listing
+        .expect(HttpStatus.FORBIDDEN);
     });
   });
 
@@ -205,7 +205,7 @@ describe('ConversationsController (e2e)', () => {
         .get(
           `/api/v1/namespaces/invalid-namespace/conversations/${conversationId}`,
         )
-        .expect(HttpStatus.OK); // Changed from FORBIDDEN - API doesn't validate namespace ownership
+        .expect(HttpStatus.FORBIDDEN);
     });
   });
 
@@ -322,7 +322,7 @@ describe('ConversationsController (e2e)', () => {
         .get(
           `/api/v1/namespaces/${client.namespace.id}/conversations/${conversationId}`,
         )
-        .expect(HttpStatus.INTERNAL_SERVER_ERROR); // Changed from NOT_FOUND
+        .expect(HttpStatus.FORBIDDEN);
     });
 
     it('should fail with non-existent conversation', async () => {
@@ -338,7 +338,7 @@ describe('ConversationsController (e2e)', () => {
         .delete(
           `/api/v1/namespaces/invalid-namespace/conversations/${conversationId}`,
         )
-        .expect(HttpStatus.INTERNAL_SERVER_ERROR); // Changed from FORBIDDEN
+        .expect(HttpStatus.FORBIDDEN);
     });
   });
 

--- a/src/conversations/conversations.e2e-spec.ts
+++ b/src/conversations/conversations.e2e-spec.ts
@@ -378,7 +378,43 @@ describe('ConversationsController (e2e)', () => {
         .get(
           `/api/v1/namespaces/${client.namespace.id}/conversations/${conversationId}`,
         )
-        .expect(HttpStatus.INTERNAL_SERVER_ERROR); // Changed from FORBIDDEN
+        .expect(HttpStatus.FORBIDDEN);
+    });
+
+    it("should fail when updating another user's conversation", async () => {
+      const anotherClient = await TestClient.create();
+      tempClients.push(anotherClient);
+
+      await anotherClient
+        .patch(
+          `/api/v1/namespaces/${client.namespace.id}/conversations/${conversationId}`,
+        )
+        .send({ title: 'Unauthorized title' })
+        .expect(HttpStatus.FORBIDDEN);
+    });
+
+    it("should fail when generating a title for another user's conversation", async () => {
+      const anotherClient = await TestClient.create();
+      tempClients.push(anotherClient);
+
+      await anotherClient
+        .post(
+          `/api/v1/namespaces/${client.namespace.id}/conversations/${conversationId}/title`,
+        )
+        .expect(HttpStatus.FORBIDDEN);
+    });
+
+    it('should fail when the conversation belongs to a different namespace', async () => {
+      const anotherNamespace = await client
+        .post('/api/v1/namespaces')
+        .send({ name: `Conversation access test ${Date.now()}` })
+        .expect(HttpStatus.CREATED);
+
+      await client
+        .get(
+          `/api/v1/namespaces/${anotherNamespace.body.id}/conversations/${conversationId}`,
+        )
+        .expect(HttpStatus.FORBIDDEN);
     });
   });
 

--- a/src/conversations/conversations.e2e-spec.ts
+++ b/src/conversations/conversations.e2e-spec.ts
@@ -3,7 +3,29 @@ import {
   MessageStatus,
   OpenAIMessageRole,
 } from 'omniboxd/messages/entities/message.entity';
+import { NamespaceRole } from 'omniboxd/namespaces/entities/namespace-member.entity';
+import { ResourcePermission } from 'omniboxd/permissions/resource-permission.enum';
 import { TestClient } from 'test/test-client';
+
+async function addNamespaceMember(
+  owner: TestClient,
+  member: TestClient,
+  namespaceId: string,
+) {
+  const invitation = await owner
+    .post(`/api/v1/namespaces/${namespaceId}/invitations`)
+    .send({
+      namespaceRole: NamespaceRole.MEMBER,
+      rootPermission: ResourcePermission.FULL_ACCESS,
+    })
+    .expect(HttpStatus.CREATED);
+
+  await member
+    .post(
+      `/api/v1/namespaces/${namespaceId}/invitations/${invitation.body.id}/accept`,
+    )
+    .expect(HttpStatus.CREATED);
+}
 
 describe('ConversationsController (e2e)', () => {
   let client: TestClient;
@@ -43,6 +65,37 @@ describe('ConversationsController (e2e)', () => {
       await client
         .post('/api/v1/namespaces/invalid-namespace/conversations')
         .expect(HttpStatus.FORBIDDEN);
+    });
+  });
+
+  describe('POST /api/v1/namespaces/:namespaceId/conversations/:id/messages', () => {
+    it('rejects a namespace member writing to another user conversation without creating a message', async () => {
+      const member = await TestClient.create();
+      tempClients.push(member);
+      await addNamespaceMember(client, member, client.namespace.id);
+      const conversation = await client
+        .post(`/api/v1/namespaces/${client.namespace.id}/conversations`)
+        .expect(HttpStatus.CREATED);
+
+      await member
+        .post(
+          `/api/v1/namespaces/${client.namespace.id}/conversations/${conversation.body.id}/messages`,
+        )
+        .send({
+          message: {
+            role: OpenAIMessageRole.USER,
+            content: 'This must not be persisted',
+          },
+          status: MessageStatus.SUCCESS,
+        })
+        .expect(HttpStatus.FORBIDDEN);
+
+      const detail = await client
+        .get(
+          `/api/v1/namespaces/${client.namespace.id}/conversations/${conversation.body.id}`,
+        )
+        .expect(HttpStatus.OK);
+      expect(Object.keys(detail.body.mapping)).toHaveLength(0);
     });
   });
 

--- a/src/conversations/conversations.module.ts
+++ b/src/conversations/conversations.module.ts
@@ -9,12 +9,14 @@ import { TasksModule } from 'omniboxd/tasks/tasks.module';
 import { WizardAPIModule } from 'omniboxd/wizard-api/wizard-api.module';
 
 import { MessagesModule } from '../messages/messages.module';
+import { NamespacesModule } from '../namespaces/namespaces.module';
 import { UserModule } from '../user/user.module';
 
 @Module({
   imports: [
     WizardAPIModule,
     MessagesModule,
+    NamespacesModule,
     UserModule,
     TasksModule,
     SharesModule,

--- a/src/conversations/conversations.service.ts
+++ b/src/conversations/conversations.service.ts
@@ -295,7 +295,7 @@ export class ConversationsService {
     });
     if (!conversation) {
       throw new AppException(
-        this.i18n.t('namespace.errors.notAMember'),
+        this.i18n.t('conversation.errors.accessDenied'),
         'CONVERSATION_ACCESS_DENIED',
         HttpStatus.FORBIDDEN,
       );

--- a/src/conversations/conversations.service.ts
+++ b/src/conversations/conversations.service.ts
@@ -13,6 +13,7 @@ import {
   OpenAIMessageRole,
 } from 'omniboxd/messages/entities/message.entity';
 import { MessagesService } from 'omniboxd/messages/messages.service';
+import { NamespacesService } from 'omniboxd/namespaces/namespaces.service';
 import { Share } from 'omniboxd/shares/entities/share.entity';
 import { WizardTaskService } from 'omniboxd/tasks/wizard-task.service';
 import { UserService } from 'omniboxd/user/user.service';
@@ -29,6 +30,7 @@ export class ConversationsService {
     private readonly conversationRepository: Repository<Conversation>,
     private readonly dataSource: DataSource,
     private readonly messagesService: MessagesService,
+    private readonly namespacesService: NamespacesService,
     private readonly userService: UserService,
     private readonly wizardApiService: WizardAPIService,
     private readonly wizardTaskService: WizardTaskService,
@@ -36,6 +38,7 @@ export class ConversationsService {
   ) {}
 
   async create(namespaceId: string, userId: string) {
+    await this.namespacesService.getMe(namespaceId, userId);
     const conversation = this.conversationRepository.create({
       namespaceId,
       userId: userId,
@@ -54,8 +57,12 @@ export class ConversationsService {
     return await this.conversationRepository.save(conversation);
   }
 
-  async update(id: string, title: string) {
-    const conversation = await this.findOne(id);
+  async update(namespaceId: string, id: string, userId: string, title: string) {
+    const conversation = await this.findOneForUserInNamespace(
+      id,
+      userId,
+      namespaceId,
+    );
     conversation.title = title;
     await this.conversationRepository.save(conversation);
   }
@@ -116,10 +123,16 @@ export class ConversationsService {
     return composed;
   }
 
-  async createTitle(id: string, userId: string): Promise<{ title: string }> {
-    const conversation = await this.conversationRepository.findOneOrFail({
-      where: { id, userId },
-    });
+  async createTitle(
+    namespaceId: string,
+    id: string,
+    userId: string,
+  ): Promise<{ title: string }> {
+    const conversation = await this.findOneForUserInNamespace(
+      id,
+      userId,
+      namespaceId,
+    );
     if (conversation.title) {
       return { title: conversation.title };
     }
@@ -174,6 +187,7 @@ export class ConversationsService {
     total: number;
     data: ConversationSummaryDto[];
   }> {
+    await this.namespacesService.getMe(namespaceId, userId);
     const conversations = await this.findAll(namespaceId, userId, options);
     const summaries: ConversationSummaryDto[] = await Promise.all(
       conversations.map((c) => this.getSummary(userId, c)),
@@ -234,12 +248,15 @@ export class ConversationsService {
   }
 
   async getConversationForUser(
+    namespaceId: string,
     conversationId: string,
     userId: string,
   ): Promise<ConversationDetailDto> {
-    const conversation = await this.conversationRepository.findOneOrFail({
-      where: { id: conversationId, userId: userId },
-    });
+    const conversation = await this.findOneForUserInNamespace(
+      conversationId,
+      userId,
+      namespaceId,
+    );
     const messages = await this.messagesService.findAll(
       userId,
       conversation.id,
@@ -272,12 +289,22 @@ export class ConversationsService {
     userId: string,
     namespaceId: string,
   ) {
-    return await this.conversationRepository.findOneOrFail({
+    await this.namespacesService.getMe(namespaceId, userId);
+    const conversation = await this.conversationRepository.findOne({
       where: { id: conversationId, userId, namespaceId },
     });
+    if (!conversation) {
+      throw new AppException(
+        this.i18n.t('namespace.errors.notAMember'),
+        'CONVERSATION_ACCESS_DENIED',
+        HttpStatus.FORBIDDEN,
+      );
+    }
+    return conversation;
   }
 
   async remove(namespaceId: string, userId: string, conversationId: string) {
+    await this.findOneForUserInNamespace(conversationId, userId, namespaceId);
     await transaction(this.dataSource.manager, async (tx) => {
       await this.wizardTaskService.emitDeleteConversationTask(
         namespaceId,
@@ -296,6 +323,7 @@ export class ConversationsService {
   }
 
   async restore(namespaceId: string, userId: string, conversationId: string) {
+    await this.findOneForUserInNamespace(conversationId, userId, namespaceId);
     const messages = await this.messagesService.findAll(userId, conversationId);
     return await transaction(this.dataSource.manager, async (tx) => {
       for (const message of messages) {

--- a/src/i18n/en/conversation.json
+++ b/src/i18n/en/conversation.json
@@ -1,0 +1,5 @@
+{
+  "errors": {
+    "accessDenied": "You do not have permission to access this conversation"
+  }
+}

--- a/src/i18n/zh/conversation.json
+++ b/src/i18n/zh/conversation.json
@@ -1,0 +1,5 @@
+{
+  "errors": {
+    "accessDenied": "您没有权限访问此对话"
+  }
+}

--- a/src/messages/messages.module.ts
+++ b/src/messages/messages.module.ts
@@ -1,13 +1,20 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { Conversation } from 'omniboxd/conversations/entities/conversation.entity';
 import { Message } from 'omniboxd/messages/entities/message.entity';
 import { MessagesController } from 'omniboxd/messages/messages.controller';
 import { MessagesService } from 'omniboxd/messages/messages.service';
 import { Task } from 'omniboxd/tasks/tasks.entity';
 import { TasksModule } from 'omniboxd/tasks/tasks.module';
 
+import { NamespacesModule } from '../namespaces/namespaces.module';
+
 @Module({
-  imports: [TasksModule, TypeOrmModule.forFeature([Message, Task])],
+  imports: [
+    TasksModule,
+    NamespacesModule,
+    TypeOrmModule.forFeature([Conversation, Message, Task]),
+  ],
   providers: [MessagesService],
   controllers: [MessagesController],
   exports: [MessagesService],

--- a/src/messages/messages.service.ts
+++ b/src/messages/messages.service.ts
@@ -1,5 +1,6 @@
 import { HttpStatus, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { I18nService } from 'nestjs-i18n';
 import { AppException } from 'omniboxd/common/exceptions/app.exception';
 import { Conversation } from 'omniboxd/conversations/entities/conversation.entity';
 import { CreateMessageDto } from 'omniboxd/messages/dto/create-message.dto';
@@ -31,6 +32,7 @@ export class MessagesService {
     private readonly dataSource: DataSource,
     private readonly wizardTaskService: WizardTaskService,
     private readonly namespacesService: NamespacesService,
+    private readonly i18n: I18nService,
   ) {}
 
   async create(
@@ -49,7 +51,7 @@ export class MessagesService {
       });
       if (!ownsConversation) {
         throw new AppException(
-          'Not authorized',
+          this.i18n.t('conversation.errors.accessDenied'),
           'CONVERSATION_ACCESS_DENIED',
           HttpStatus.FORBIDDEN,
         );

--- a/src/messages/messages.service.ts
+++ b/src/messages/messages.service.ts
@@ -1,11 +1,14 @@
-import { Injectable } from '@nestjs/common';
+import { HttpStatus, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { AppException } from 'omniboxd/common/exceptions/app.exception';
+import { Conversation } from 'omniboxd/conversations/entities/conversation.entity';
 import { CreateMessageDto } from 'omniboxd/messages/dto/create-message.dto';
 import {
   Message,
   MessageStatus,
   OpenAIMessage,
 } from 'omniboxd/messages/entities/message.entity';
+import { NamespacesService } from 'omniboxd/namespaces/namespaces.service';
 import { WizardTaskService } from 'omniboxd/tasks/wizard-task.service';
 import { User } from 'omniboxd/user/entities/user.entity';
 import { transaction } from 'omniboxd/utils/transaction-utils';
@@ -23,8 +26,11 @@ export class MessagesService {
   constructor(
     @InjectRepository(Message)
     private readonly messageRepository: Repository<Message>,
+    @InjectRepository(Conversation)
+    private readonly conversationRepository: Repository<Conversation>,
     private readonly dataSource: DataSource,
     private readonly wizardTaskService: WizardTaskService,
+    private readonly namespacesService: NamespacesService,
   ) {}
 
   async create(
@@ -34,6 +40,21 @@ export class MessagesService {
     dto: CreateMessageDto,
     index: boolean = true,
   ): Promise<Message> {
+    if (userId) {
+      await this.namespacesService.getMe(namespaceId, userId);
+      const ownsConversation = await this.conversationRepository.existsBy({
+        id: conversationId,
+        namespaceId,
+        userId,
+      });
+      if (!ownsConversation) {
+        throw new AppException(
+          'Not authorized',
+          'CONVERSATION_ACCESS_DENIED',
+          HttpStatus.FORBIDDEN,
+        );
+      }
+    }
     const message = this.messageRepository.create({
       message: dto.message,
       conversationId,

--- a/src/wizard/stream.service.spec.ts
+++ b/src/wizard/stream.service.spec.ts
@@ -11,6 +11,7 @@ function createService(mocks: {
     { get: jest.fn() } as any,
     {} as any,
     {} as any,
+    {} as any,
     mocks.namespaceResourcesService as any,
     mocks.sharedResourcesService as any,
     mocks.resourcesService as any,

--- a/src/wizard/stream.service.spec.ts
+++ b/src/wizard/stream.service.spec.ts
@@ -2,6 +2,7 @@ import { ResourceType } from 'omniboxd/resources/entities/resource.entity';
 import { StreamService } from 'omniboxd/wizard/stream.service';
 
 function createService(mocks: {
+  conversationsService?: Record<string, jest.Mock>;
   namespaceResourcesService?: Record<string, jest.Mock>;
   sharedResourcesService?: Record<string, jest.Mock>;
   resourcesService?: Record<string, jest.Mock>;
@@ -11,7 +12,7 @@ function createService(mocks: {
     { get: jest.fn() } as any,
     {} as any,
     {} as any,
-    {} as any,
+    mocks.conversationsService as any,
     mocks.namespaceResourcesService as any,
     mocks.sharedResourcesService as any,
     mocks.resourcesService as any,
@@ -19,6 +20,71 @@ function createService(mocks: {
     {} as any,
   );
 }
+
+describe('StreamService conversation ownership', () => {
+  const accessDenied = new Error('conversation access denied');
+
+  it.each(['ask', 'write'] as const)(
+    'rejects %s before creating a user agent stream',
+    async (action) => {
+      const conversationsService = {
+        findOneForUserInNamespace: jest.fn().mockRejectedValue(accessDenied),
+      };
+      const service = createService({ conversationsService });
+      const createAgentStream = jest.spyOn(service as any, 'createAgentStream');
+
+      await expect(
+        service.createUserAgentStream(
+          'user-id',
+          'namespace-id',
+          {
+            conversation_id: 'conversation-id',
+          } as any,
+          'request-id',
+          action,
+        ),
+      ).rejects.toBe(accessDenied);
+
+      expect(createAgentStream).not.toHaveBeenCalled();
+    },
+  );
+
+  it('rejects resume before reading stream state', async () => {
+    const conversationsService = {
+      findOneForUserInNamespace: jest.fn().mockRejectedValue(accessDenied),
+    };
+    const service = createService({ conversationsService });
+    const resumeAgentStream = jest.spyOn(service as any, 'resumeAgentStream');
+
+    await expect(
+      service.resumeUserAgentStream(
+        'user-id',
+        'namespace-id',
+        'conversation-id',
+      ),
+    ).rejects.toBe(accessDenied);
+
+    expect(resumeAgentStream).not.toHaveBeenCalled();
+  });
+
+  it('rejects cancel before mutating stream state', async () => {
+    const conversationsService = {
+      findOneForUserInNamespace: jest.fn().mockRejectedValue(accessDenied),
+    };
+    const service = createService({ conversationsService });
+    const cancelAgentStream = jest.spyOn(service as any, 'cancelAgentStream');
+
+    await expect(
+      service.cancelUserAgentStream(
+        'user-id',
+        'namespace-id',
+        'conversation-id',
+      ),
+    ).rejects.toBe(accessDenied);
+
+    expect(cancelAgentStream).not.toHaveBeenCalled();
+  });
+});
 
 describe('StreamService agent handler', () => {
   it('sends the persisted message creation time in bos data', async () => {

--- a/src/wizard/stream.service.ts
+++ b/src/wizard/stream.service.ts
@@ -1018,12 +1018,12 @@ export class StreamService implements OnModuleDestroy {
     requestId: string,
     mode: 'ask' | 'write',
   ): Promise<Observable<MessageEvent>> {
+    await this.conversationsService.findOneForUserInNamespace(
+      requestDto.conversation_id,
+      userId,
+      namespaceId,
+    );
     try {
-      await this.conversationsService.findOneForUserInNamespace(
-        requestDto.conversation_id,
-        userId,
-        namespaceId,
-      );
       for (const tool of requestDto.tools || []) {
         if (tool.name === 'private_search') {
           tool.visible_resources = await this.getUserVisibleResources(

--- a/src/wizard/stream.service.ts
+++ b/src/wizard/stream.service.ts
@@ -10,6 +10,7 @@ import { trace } from '@opentelemetry/api';
 import { I18nService } from 'nestjs-i18n';
 import { Span } from 'nestjs-otel';
 import { AppException } from 'omniboxd/common/exceptions/app.exception';
+import { ConversationsService } from 'omniboxd/conversations/conversations.service';
 import {
   Message,
   MessageStatus,
@@ -73,6 +74,7 @@ export class StreamService implements OnModuleDestroy {
     private readonly configService: ConfigService,
     private readonly wizardApiService: WizardAPIService,
     private readonly messagesService: MessagesService,
+    private readonly conversationsService: ConversationsService,
     private readonly namespaceResourcesService: NamespaceResourcesService,
     private readonly sharedResourcesService: SharedResourcesService,
     private readonly resourcesService: ResourcesService,
@@ -860,12 +862,17 @@ export class StreamService implements OnModuleDestroy {
     }
   }
 
-  resumeUserAgentStream(
+  async resumeUserAgentStream(
     userId: string,
     namespaceId: string,
     conversationId: string,
     lastEventId?: string,
-  ): Observable<MessageEvent> {
+  ): Promise<Observable<MessageEvent>> {
+    await this.conversationsService.findOneForUserInNamespace(
+      conversationId,
+      userId,
+      namespaceId,
+    );
     return this.resumeAgentStream(
       this.getStreamKey(namespaceId, conversationId, userId),
       lastEventId,
@@ -963,6 +970,11 @@ export class StreamService implements OnModuleDestroy {
     namespaceId: string,
     conversationId: string,
   ) {
+    await this.conversationsService.findOneForUserInNamespace(
+      conversationId,
+      userId,
+      namespaceId,
+    );
     await this.cancelAgentStream(
       this.getStreamKey(namespaceId, conversationId, userId),
       namespaceId,
@@ -1007,6 +1019,11 @@ export class StreamService implements OnModuleDestroy {
     mode: 'ask' | 'write',
   ): Promise<Observable<MessageEvent>> {
     try {
+      await this.conversationsService.findOneForUserInNamespace(
+        requestDto.conversation_id,
+        userId,
+        namespaceId,
+      );
       for (const tool of requestDto.tools || []) {
         if (tool.name === 'private_search') {
           tool.visible_resources = await this.getUserVisibleResources(

--- a/src/wizard/wizard.e2e-spec.ts
+++ b/src/wizard/wizard.e2e-spec.ts
@@ -71,11 +71,14 @@ describe('WizardController (e2e)', () => {
           )
           .expect(HttpStatus.OK);
 
-        await memberClient
+        const response = await memberClient
           .post(`/api/v1/namespaces/${client.namespace.id}/wizard/${endpoint}`)
           .set('X-Request-Id', `unauthorized-${endpoint}`)
-          .send(agentBody(ownerConversationId))
-          .expect(HttpStatus.FORBIDDEN);
+          .send(agentBody(ownerConversationId));
+
+        // SSE commits the POST response before surfacing the stream error.
+        expect(response.status).toBe(HttpStatus.CREATED);
+        expect(response.headers['content-type']).toContain('text/event-stream');
 
         const after = await client
           .get(
@@ -88,17 +91,22 @@ describe('WizardController (e2e)', () => {
       },
     );
 
-    it.each(['resume', 'cancel'])(
-      'rejects stream %s for another namespace member',
-      async (endpoint) => {
-        await memberClient
-          .post(
-            `/api/v1/namespaces/${client.namespace.id}/wizard/stream/${endpoint}`,
-          )
-          .send({ conversation_id: ownerConversationId })
-          .expect(HttpStatus.FORBIDDEN);
-      },
-    );
+    it('rejects stream resume for another namespace member without exposing events', async () => {
+      const response = await memberClient
+        .post(`/api/v1/namespaces/${client.namespace.id}/wizard/stream/resume`)
+        .send({ conversation_id: ownerConversationId })
+        .expect(HttpStatus.CREATED);
+
+      expect(response.headers['content-type']).toContain('text/event-stream');
+      expect(response.text).not.toContain(ownerConversationId);
+    });
+
+    it('rejects stream cancel for another namespace member', async () => {
+      await memberClient
+        .post(`/api/v1/namespaces/${client.namespace.id}/wizard/stream/cancel`)
+        .send({ conversation_id: ownerConversationId })
+        .expect(HttpStatus.FORBIDDEN);
+    });
   });
 
   describe('POST /api/v1/namespaces/:namespaceId/wizard/ask', () => {

--- a/src/wizard/wizard.e2e-spec.ts
+++ b/src/wizard/wizard.e2e-spec.ts
@@ -1,4 +1,6 @@
 import { HttpStatus } from '@nestjs/common';
+import { NamespaceRole } from 'omniboxd/namespaces/entities/namespace-member.entity';
+import { ResourcePermission } from 'omniboxd/permissions/resource-permission.enum';
 import { TestClient } from 'test/test-client';
 
 process.env.OBB_WIZARD_BASE_URL = 'http://localhost:8000';
@@ -23,13 +25,80 @@ global.fetch = jest.fn().mockResolvedValue({
 
 describe('WizardController (e2e)', () => {
   let client: TestClient;
+  let memberClient: TestClient;
+  let ownerConversationId: string;
 
   beforeAll(async () => {
     client = await TestClient.create();
+    memberClient = await TestClient.create();
+    const invitation = await client
+      .post(`/api/v1/namespaces/${client.namespace.id}/invitations`)
+      .send({
+        namespaceRole: NamespaceRole.MEMBER,
+        rootPermission: ResourcePermission.FULL_ACCESS,
+      })
+      .expect(HttpStatus.CREATED);
+    await memberClient
+      .post(
+        `/api/v1/namespaces/${client.namespace.id}/invitations/${invitation.body.id}/accept`,
+      )
+      .expect(HttpStatus.CREATED);
+    const conversation = await client
+      .post(`/api/v1/namespaces/${client.namespace.id}/conversations`)
+      .expect(HttpStatus.CREATED);
+    ownerConversationId = conversation.body.id;
   });
 
   afterAll(async () => {
     await client.close();
+    await memberClient.close();
+  });
+
+  describe('Conversation ownership', () => {
+    const agentBody = (conversationId: string) => ({
+      query: 'Do not process this request',
+      conversation_id: conversationId,
+      tools: [],
+      enable_thinking: false,
+    });
+
+    it.each(['ask', 'write'])(
+      'rejects %s for another namespace member without creating messages',
+      async (endpoint) => {
+        const before = await client
+          .get(
+            `/api/v1/namespaces/${client.namespace.id}/conversations/${ownerConversationId}`,
+          )
+          .expect(HttpStatus.OK);
+
+        await memberClient
+          .post(`/api/v1/namespaces/${client.namespace.id}/wizard/${endpoint}`)
+          .set('X-Request-Id', `unauthorized-${endpoint}`)
+          .send(agentBody(ownerConversationId))
+          .expect(HttpStatus.FORBIDDEN);
+
+        const after = await client
+          .get(
+            `/api/v1/namespaces/${client.namespace.id}/conversations/${ownerConversationId}`,
+          )
+          .expect(HttpStatus.OK);
+        expect(Object.keys(after.body.mapping)).toHaveLength(
+          Object.keys(before.body.mapping).length,
+        );
+      },
+    );
+
+    it.each(['resume', 'cancel'])(
+      'rejects stream %s for another namespace member',
+      async (endpoint) => {
+        await memberClient
+          .post(
+            `/api/v1/namespaces/${client.namespace.id}/wizard/stream/${endpoint}`,
+          )
+          .send({ conversation_id: ownerConversationId })
+          .expect(HttpStatus.FORBIDDEN);
+      },
+    );
   });
 
   describe('POST /api/v1/namespaces/:namespaceId/wizard/ask', () => {


### PR DESCRIPTION
## Summary\n\n- require namespace membership and conversation ownership before returning or mutating conversation data\n- protect message creation and stream start, resume, and cancellation paths\n- add cross-user and cross-namespace conversation access coverage\n\n## Verification\n\n- backend lint and TypeScript checks passed before syncing\n- stream.service.spec.ts and open.wizard.service.spec.ts: 13 tests passed\n- full e2e suite was not run because Docker is unavailable locally\n\n## Security impact\n\nPrevents authenticated users from reading or operating on another user's conversation by opening a URL containing its conversation ID.