### PR TITLE
ci: Build amd64-only images for non-tag deploys

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,9 +123,7 @@ jobs:
           push: true
           tags: ${{ steps.meta_app.outputs.tags }}
           labels: ${{ steps.meta_app.outputs.labels }}
-          platforms: |
-            linux/amd64
-            linux/arm64
+          platforms: ${{ startsWith(github.ref, 'refs/tags/') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
## Summary
- For non-tag builds (test/pre deploys), build Docker images for `linux/amd64` only.
- For tag/release builds, keep multi-arch `linux/amd64,linux/arm64`.

This cuts CI time and resources for routine environment deploys while preserving multi-arch images for releases.

## Test plan
- [ ] Push to this branch and confirm the image build job uses `linux/amd64` only
- [ ] Tag a release (or dry-run the expression) and confirm platforms become `linux/amd64,linux/arm64`
- [ ] Verify test/pre deploy still pulls and runs the amd64 image successfully